### PR TITLE
Fix Homepage Dark Mode

### DIFF
--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -31,7 +31,7 @@ function Card({
 }: RenderableProps<CardProps>): JSX.Element {
   return (
     <div
-      class={`inline-grid items-center rounded-xl bg-slate-300 dark:bg-slate-200 p-8 md:grid md:grid-cols-4 ${cols}`}
+      class={`inline-grid items-center rounded-xl bg-slate-300 dark:bg-slate-700 p-8 md:grid md:grid-cols-4 ${cols}`}
     >
       <img
         src={image}
@@ -45,7 +45,7 @@ function Card({
       />
 
       <p
-        class={`prose prose-slate prose-xl p-4 md:row-start-1 md:row-end-2 ${
+        class={`prose prose-slate prose-xl dark:prose-invert p-4 md:row-start-1 md:row-end-2 ${
           imgSide === "left"
             ? "md:col-start-2 md:col-end-5"
             : "md:col-start-1 md:col-end-4"


### PR DESCRIPTION
## Description

This PR fixes the dark mode of the homepage to invert without getting too bright.

_Closes: #38_

---

## Type of Change

- 🐛 Bug fix

## Checklist

```[tasklist]
### Checklist
- [x] Read the Contributing Guidelines.
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Fill out this template.
- [ ] Log your hours.
- [x] Check that commits follow the Angular commit convention, more or less.
- [ ] Ideally, include relevant tests that fail without this PR but pass with it (if applicable).
```

## Tested on

- macOS 14
