### PR TITLE
Fix CSP

### DIFF
--- a/src/utils/csp.ts
+++ b/src/utils/csp.ts
@@ -1,4 +1,10 @@
-import { SELF, STRICT_DYNAMIC, UNSAFE_INLINE, useCSP } from "$fresh/runtime.ts";
+import {
+  NONE,
+  SELF,
+  STRICT_DYNAMIC,
+  UNSAFE_INLINE,
+  useCSP,
+} from "$fresh/runtime.ts";
 
 export function useCsp(): void {
   useCSP((csp) => {
@@ -9,13 +15,15 @@ export function useCsp(): void {
     csp.directives.imgSrc ??= [];
     csp.directives.connectSrc ??= [];
     csp.directives.manifestSrc ??= [];
+    csp.directives.baseUri ??= [];
 
-    csp.directives.scriptSrc.push(STRICT_DYNAMIC);
+    csp.directives.scriptSrc.push(STRICT_DYNAMIC, UNSAFE_INLINE);
     csp.directives.scriptSrcElem.push(SELF, UNSAFE_INLINE);
     csp.directives.styleSrc.push(SELF);
     csp.directives.styleSrcElem.push(SELF, STRICT_DYNAMIC);
     csp.directives.imgSrc.push(SELF, "data:");
     csp.directives.connectSrc.push(SELF);
     csp.directives.manifestSrc.push(SELF);
+    csp.directives.baseUri.push(NONE);
   });
 }

--- a/src/utils/csp.ts
+++ b/src/utils/csp.ts
@@ -1,7 +1,8 @@
-import { SELF, UNSAFE_INLINE, useCSP } from "$fresh/runtime.ts";
+import { SELF, STRICT_DYNAMIC, UNSAFE_INLINE, useCSP } from "$fresh/runtime.ts";
 
 export function useCsp(): void {
   useCSP((csp) => {
+    csp.directives.scriptSrc ??= [];
     csp.directives.scriptSrcElem ??= [];
     csp.directives.styleSrc ??= [];
     csp.directives.styleSrcElem ??= [];
@@ -9,9 +10,10 @@ export function useCsp(): void {
     csp.directives.connectSrc ??= [];
     csp.directives.manifestSrc ??= [];
 
+    csp.directives.scriptSrc.push(STRICT_DYNAMIC);
     csp.directives.scriptSrcElem.push(SELF, UNSAFE_INLINE);
     csp.directives.styleSrc.push(SELF);
-    csp.directives.styleSrcElem.push(SELF, UNSAFE_INLINE);
+    csp.directives.styleSrcElem.push(SELF, STRICT_DYNAMIC);
     csp.directives.imgSrc.push(SELF, "data:");
     csp.directives.connectSrc.push(SELF);
     csp.directives.manifestSrc.push(SELF);

--- a/src/utils/csp.ts
+++ b/src/utils/csp.ts
@@ -12,7 +12,7 @@ export function useCsp(): void {
     csp.directives.scriptSrcElem.push(SELF, UNSAFE_INLINE);
     csp.directives.styleSrc.push(SELF);
     csp.directives.styleSrcElem.push(SELF, UNSAFE_INLINE);
-    csp.directives.imgSrc.push(SELF);
+    csp.directives.imgSrc.push(SELF, "data:");
     csp.directives.connectSrc.push(SELF);
     csp.directives.manifestSrc.push(SELF);
   });


### PR DESCRIPTION
## Description

Without this, the checkboxes are not rendered correctly—they weren't checked when the user clicked on them. This was due to another annoying CSP violation. This was an oversight on my part; I apologize, I hope this is the last time we have to fix this.

---

## Type of Change

- 🐛 Bug fix

## Checklist

```[tasklist]
### Checklist
- [x] Read the Contributing Guidelines.
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Fill out this template.
- [ ] Log your hours.
- [x] Check that commits follow the Angular commit convention, more or less.
- [ ] Ideally, include relevant tests that fail without this PR but pass with it (if applicable).
```

## Tested on

- macOS 14
