### PR TITLE
Fix Missing Partial Island Warning

### DIFF
--- a/src/routes/_app.tsx
+++ b/src/routes/_app.tsx
@@ -1,4 +1,4 @@
-import { Head, asset } from "$fresh/runtime.ts";
+import { Head, Partial, asset } from "$fresh/runtime.ts";
 import type { PageProps } from "$fresh/server.ts";
 import type { JSX } from "preact";
 import {
@@ -71,7 +71,9 @@ export default function App({ Component }: PageProps): JSX.Element {
       </Head>
 
       <body f-client-nav class="dark:bg-slate-950 dark:text-slate-50">
-        <Component />
+        <Partial name="body">
+          <Component />
+        </Partial>
       </body>
     </html>
   );

--- a/src/routes/_layout.tsx
+++ b/src/routes/_layout.tsx
@@ -1,4 +1,3 @@
-import { Partial } from "$fresh/runtime.ts";
 import type { PageProps } from "$fresh/server.ts";
 import type { JSX } from "preact";
 import { Footer } from "../components/Footer.tsx";
@@ -16,10 +15,8 @@ import { Chatbot } from "../islands/Chatbot.tsx";
 export default function Layout({ Component, url }: PageProps): JSX.Element {
   return (
     <div class="flex min-h-screen flex-col place-content-center">
-      <Partial name="body">
-        <Header active={url.pathname} />
-        <Component />
-      </Partial>
+      <Header active={url.pathname} />
+      <Component />
       <Chatbot class="fixed right-3 bottom-10 sm:right-10" />
       <Footer class="mt-auto" />
     </div>


### PR DESCRIPTION
## Description

Apparently, f-client-nav requires the direct child to be a partial.
It works fine otherwise, so I hadn't noticed.
However, it appears that `f-client-nav`ed islands must be partialled.

---

## Type of Change

- 🐛 Bug fix

## Checklist

```[tasklist]
### Checklist
- [x] Read the Contributing Guidelines.
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Fill out this template.
- [ ] Log your hours.
- [x] Check that commits follow the Angular commit convention, more or less.
- [ ] Ideally, include relevant tests that fail without this PR but pass with it (if applicable).
```

## Tested on

- macOS 14
